### PR TITLE
Back to old way, but new mapString

### DIFF
--- a/JKJO.asl
+++ b/JKJO.asl
@@ -3,7 +3,7 @@ state("jk2sp")
 	int isLoading      :  0x41D45C;
 	int Loading2       :  0xEF5200;
 	int map            :  0x5E6098;
-	int desannHealth   :  "jk2gamex86.dll", 0x26CF78, 0x218;
+	int finalsplit     :  0x41D59C;
 	int start          :  0x40D370;
 	string9 mapString  :  0x4226F9;
 }
@@ -20,7 +20,7 @@ reset
 split
 {
 	return current.map != old.map && current.map > 2 ||
-		   current.mapString == "yavin_fin" && current.desannHealth == 0 && old.desannHealth > 0;
+		   current.mapString == "yavin_fin" && current.finalsplit == 1;
 }
 
 isLoading


### PR DESCRIPTION
From what we've gathered, the issue was the mapString address, not finalSplit, and while the Desan health could have worked, it just changes so many times, there is a fair change, LiveSplit will split a couple of times during that level. So that should solve everything.
