### PR TITLE
Add Tomb Raider 2013 Support For Steam Version 0.0

### DIFF
--- a/TombRaider.asl
+++ b/TombRaider.asl
@@ -1,3 +1,10 @@
+state("TombRaider", "[Steam] 0.0")
+{
+    bool FMV             : "binkw32.dll", 0x2830C;
+    int  ingameCutscene  : 0x20C97C0;
+    bool isLoading       : 0x1CF7FE0;
+}
+
 state("TombRaider", "[Epic Games] 838.0")
 {
     bool FMV             : "binkw32.dll", 0x2830C;
@@ -22,6 +29,9 @@ init
 {
     switch(modules.FirstOrDefault(r => r.ModuleName == "TombRaider.exe").ModuleMemorySize)
     {
+        case 38543360:
+            version = "[Steam] 0.0";
+            break;
         case 38535168:
             version = "[Epic Games] 838.0";
             break;

--- a/TombRaider.asl
+++ b/TombRaider.asl
@@ -5,7 +5,7 @@ state("TombRaider", "[Steam] 0.0")
     bool isLoading       : 0x1CF7FE0;
 }
 
-state("TombRaider", "[Epic Games] 838.0")
+state("TombRaider", "[Epic Games] 0.0")
 {
     bool FMV             : "binkw32.dll", 0x2830C;
     int  ingameCutscene  : 0x20C7DBC;

--- a/TombRaider.asl
+++ b/TombRaider.asl
@@ -5,7 +5,7 @@ state("TombRaider", "[Steam] 0.0")
     bool isLoading       : 0x1CF7FE0;
 }
 
-state("TombRaider", "[Epic Games] 838.0")
+state("TombRaider", "[Epic Games] 0.0")
 {
     bool FMV             : "binkw32.dll", 0x2830C;
     int  ingameCutscene  : 0x20C7DBC;
@@ -33,7 +33,7 @@ init
             version = "[Steam] 0.0";
             break;
         case 38535168:
-            version = "[Epic Games] 838.0";
+            version = "[Epic Games] 0.0";
             break;
         case 38739968:
             version = "[Steam] 743.0";


### PR DESCRIPTION
Hi, this adds support for the latest Steam version (0.0).

I also renamed the latest Epic Games version to 0.0 since it seems to have changed.

Thanks.